### PR TITLE
Test/test for session timeout bug

### DIFF
--- a/sorcery.gemspec
+++ b/sorcery.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'oauth2', '~> 2.0'
 
   s.add_development_dependency 'byebug', '~> 10.0.0'
-  s.add_development_dependency 'rspec-rails', '~> 3.7.0'
+  s.add_development_dependency 'rspec-rails', '~> 6.0.0'
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'simplecov', '>= 0.3.8'
   s.add_development_dependency 'test-unit', '~> 3.2.0'


### PR DESCRIPTION
Hello @jankoegel,

I haven't been able to determine whether the issue with the test or the code. However, `with remember_me module enabled after session timeout` test is failing.

I believe this may be due to line 72 in the lib/sorcery/controller.rb file within the logout method. In the logged_in function, we call logout, and because of this, we are unable to reach the before_logout hook.

Let me know if you need further clarification or assistance.